### PR TITLE
Improve front page Stats19 accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ In order to import Stats19 data from scratch, you need to run through the follow
    script at any time and use the data you've got (a few reports are probably
    enough for development), or you can wait 3 minutes and re-run until you get
    enough to meet your needs - the script will skip existing reports.
+9. Don't forget to update the `LATEST_STATS19_UPDATE` constant in `Smidsy.pm`.
 
 Running this site as part of a FixMyStreet vagrant install
 ----------------------------------------------------------

--- a/perllib/FixMyStreet/Cobrand/Smidsy.pm
+++ b/perllib/FixMyStreet/Cobrand/Smidsy.pm
@@ -19,7 +19,8 @@ use constant fourweeks => 4*7*24*60*60;
 use constant language_domain => 'Smidsy';
 
 use constant STATS19_IMPORT_USER => 'hakim+smidsy@mysociety.org';
-use constant LATEST_STATS19_UPDATE => 2013; # TODO, constant for now
+use constant EARLIEST_STATS19_UPDATE => 2013; # TODO, constant for now
+use constant LATEST_STATS19_UPDATE => 2016; # TODO, constant for now
 
 sub enter_postcode_text {
     my ( $self ) = @_;
@@ -359,7 +360,7 @@ sub recent_new {
     my %keys = (
         'new'     => "recent_new:$site_key:$key",
         'miss'    => "recent_new_miss:$site_key:$key",
-        'stats19' => sprintf ("latest_stats19:$site_key:%d", LATEST_STATS19_UPDATE),
+        'stats19' => sprintf ("latest_stats19:$site_key:%d:%d", EARLIEST_STATS19_UPDATE, LATEST_STATS19_UPDATE),
     );
 
     # unfortunately, we can't just do 
@@ -379,7 +380,7 @@ sub recent_new {
 
     my $stats_rs = $rs->search( {
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
-        created => { '>=', sprintf ('%d-01-01', LATEST_STATS19_UPDATE ),
+        created => { '>=', sprintf ('%d-01-01', EARLIEST_STATS19_UPDATE ),
                         '<', sprintf ('%d-01-01', LATEST_STATS19_UPDATE+1 ) },
         $user_id ? ( user_id => $user_id ) : (),
     });

--- a/templates/web/smidsy/front/stats.html
+++ b/templates/web/smidsy/front/stats.html
@@ -3,9 +3,6 @@
 [%
     stats = c.cobrand.front_stats_data();
 
-    stats_period = stats.recency == '1 week' ? 'Week' : 
-        stats.recency == '12 months' ? 'Year' : stats.recency
-
     new_text =
         stats.recency == '1 week'
         ? nget(
@@ -43,7 +40,7 @@
     updates_n = stats.updates | format_number;
 %]
 
-      <h2>This [% stats_period %] on Collideoscope</h2>
+      <h2>Recently on Collideoscope</h2>
 
       <ul class="smidsy-four-column">
         <li>[% tprintf( new_text, new_n ) %]</li>


### PR DESCRIPTION
Makes the ‘This year on Collideoscope’ heading a bit broader,
and includes a sum total of all Stats19 incidents instead of
just the most recent import.

<img width="906" alt="image" src="https://user-images.githubusercontent.com/4776/44143706-9f2f81b2-a07c-11e8-9121-d61a7051f8e8.png">


Fixes #31.