### PR TITLE
Provide more relevant prompts to report incidents to police

### DIFF
--- a/data/police-force-urls.csv
+++ b/data/police-force-urls.csv
@@ -1,0 +1,44 @@
+avon-and-somerset|Avon and Somerset Constabulary|https://www.avonandsomerset.police.uk/contact-us/report-a-crime-or-incident/
+bedfordshire|Bedfordshire Police|https://www.bedfordshire.police.uk/report/Report-Shared/Report-road-traffic-collision
+cambridgeshire|Cambridgeshire Constabulary|https://www.cambs.police.uk/report/Report-Shared/Report-road-traffic-collision
+cheshire|Cheshire Constabulary|https://www.cheshire.police.uk/contact/
+city-of-london|City of London Police|https://www.cityoflondon.police.uk/contact-city-police/reporting-a-crime/Pages/Online-crime-report.aspx
+cleveland|Cleveland Police|https://www.cleveland.police.uk/contact-us/
+cumbria|Cumbria Constabulary|https://www.cumbria.police.uk/Report-It/Report-a-Crime/Non-Emergency-Crime-Online.aspx
+derbyshire|Derbyshire Constabulary|http://www.derbyshire.police.uk/Contact-Us/Signposting/Road-Traffic-Collisions.aspx
+devon-and-cornwall|Devon & Cornwall Police|https://services.devon-cornwall.police.uk/crimereporting/
+dorset|Dorset Police|https://www.dorset.police.uk/contact-us/call-us/
+durham|Durham Constabulary|https://www.durham.police.uk/Contact-us/Report-a-crime/Pages/default.aspx
+dyfed-powys|Dyfed-Powys Police|https://www.dyfed-powys.police.uk/en/contact-us/report-an-incident/
+essex|Essex Police|https://www.essex.police.uk/do-it-online/report-a-road-traffic-collision/
+gloucestershire|Gloucestershire Constabulary|https://www.gloucestershire.police.uk/what-do-i-do-if/i-have-been-involved-in-a-road-traffic-collision/
+greater-manchester|Greater Manchester Police|http://www.gmp.police.uk/content/triage-category?ReadForm&l2=78366&l3=20483
+gwent|Gwent Police|https://www.gwent.police.uk/en/contact-us/in-a-non-emergency-general-contact/
+hampshire|Hampshire Constabulary|https://www.hampshire.police.uk/ro/report/rti/report-a-road-traffic-incident/
+hertfordshire|Hertfordshire Constabulary|https://www.herts.police.uk/Report/Report-Shared/Report-road-traffic-collision
+humberside|Humberside Police|https://www.reportingcrime.uk/HPrisk/
+kent|Kent Police|https://www.kent.police.uk/services/report-a-collision-online/
+lancashire|Lancashire Constabulary|https://www.lancashire.police.uk/contact-us/need-advice/road-traffic-collisions/
+leicestershire|Leicestershire Police|https://leics.police.uk/report-online/road-traffic-collision
+lincolnshire|Lincolnshire Police|https://www.lincs.police.uk/contact/
+merseyside|Merseyside Police|https://www.merseyside.police.uk/advice-and-protection/policing-the-roads/road-traffic-collisions/
+metropolitan|Metropolitan Police Service|https://www.met.police.uk/ro/report/rti/report-a-road-traffic-incident/
+norfolk|Norfolk Constabulary|https://www.norfolk.police.uk/contact-us/report-something/report-road-traffic-collision
+north-wales|North Wales Police|https://www.north-wales.police.uk/contact/minor-incident-reporting
+north-yorkshire|North Yorkshire Police|https://northyorkshire.police.uk/contact/non-emergency/
+northamptonshire|Northamptonshire Police|https://www.northants.police.uk/webform/online-crime-reporting
+northumbria|Northumbria Police|https://www.northumbria.police.uk/faqs/who_to_contact/who_to_contact_about_road_traffic_collisions/
+nottinghamshire|Nottinghamshire Police|https://www.nottinghamshire.police.uk/101
+northern-ireland|Police Service of Northern Ireland|https://www.psni.police.uk/CrimeReportFormPage/
+south-wales|South Wales Police|https://www.south-wales.police.uk/en/contact-us/
+south-yorkshire|South Yorkshire Police|https://www.southyorks.police.uk/contact-us/should-i-call-101/road-traffic-collisions/
+staffordshire|Staffordshire Police|https://www.staffordshire.police.uk/collisions
+suffolk|Suffolk Constabulary|https://www.suffolk.police.uk/contact-us/report-something/report-road-traffic-collision
+surrey|Surrey Police|https://surrey.police.uk/contact-us/report-online/reporting-road-traffic-collisions/
+sussex|Sussex Police|https://sussex.police.uk/contact-us/report-online/report-a-road-traffic-collision/
+thames-valley|Thames Valley Police|https://www.thamesvalley.police.uk/ro/report/rti/report-a-road-traffic-incident/
+warwickshire|Warwickshire Police|https://www.warwickshire.police.uk/6239
+west-mercia|West Mercia Police|https://www.westmercia.police.uk/article/5996/Road-Traffic-Collisions-RTCs
+west-midlands|West Midlands Police|https://www.west-midlands.police.uk/your-options/road-traffic-collision
+west-yorkshire|West Yorkshire Police|https://www.westyorkshire.police.uk/contact-us
+wiltshire|Wiltshire Police|https://www.wiltshire.police.uk/article/1179/Accidents-and-collisions

--- a/perllib/FixMyStreet/Cobrand/Smidsy.pm
+++ b/perllib/FixMyStreet/Cobrand/Smidsy.pm
@@ -175,10 +175,6 @@ sub report_form_extras {
                 return $data;
             },
         },
-        {
-            name => 'injury_detail',
-            validator => sub { shift } # accept as is
-        },
     )
 }
 
@@ -228,13 +224,6 @@ sub report_new_munge_before_insert {
     };
 
     my $title = "$type_description involving $participants";
-
-    if (my $injury_detail = $report->get_extra_metadata('injury_detail')) {
-        $report->detail(
-            $report->detail .
-                "\n\nDetails about injuries: $injury_detail\n"
-        );
-    }
 
     $report->title($title);
 }

--- a/perllib/FixMyStreet/Cobrand/Smidsy.pm
+++ b/perllib/FixMyStreet/Cobrand/Smidsy.pm
@@ -11,7 +11,9 @@ use DateTime::Format::Strptime;
 use Utils;
 use URI;
 use URI::QueryParam;
-use JSON;
+use JSON::MaybeXS;
+use LWP::UserAgent;
+use Try::Tiny;
 use List::Util 'first';
 
 use constant fourweeks => 4*7*24*60*60;
@@ -64,12 +66,48 @@ sub get_severity {
         reverse @{ $self->severity_categories };
 }
 
+sub get_police_info {
+    my ($self, $report) = @_;
+
+    my $extra = $report->get_extra_metadata;
+    return $extra{police} if $extra{police};
+
+    my @data = eval { FixMyStreet->path_to('../collideoscope/data/police-force-urls.csv')->slurp };
+    my %data;
+    foreach (@data) {
+        chomp;
+        my ($id, $name, $url) = split /\|/;
+        $data{$id} = {
+            name => $name,
+            url => $url,
+        };
+    }
+    return unless %data;
+
+    my ($lat, $lon) = ($report->latitude, $report->longitude);
+
+    my $ua = new LWP::UserAgent();
+    $ua->agent("collideoscope.org.uk");
+    my $r = $ua->get("https://data.police.uk/api/locate-neighbourhood?q=$lat,$lon");
+
+    my $j = try {
+        JSON->new->utf8->allow_nonref->decode($r->content);
+    };
+    return unless $j && $j->{force};
+
+    my $ret = $data{$j->{force}};
+    # Set this so HTML email template can get it immediately
+    $report->set_extra_metadata('police' => $ret);
+    return $ret;
+}
+
 sub area_types          {
     my $self = shift;
     my $area_types = $self->next::method;
     [
         @$area_types,
         'GLA', # Greater London Authority
+        'POL', # Police Forces
     ];
 }
 

--- a/t/cobrand/smidsy.t
+++ b/t/cobrand/smidsy.t
@@ -78,7 +78,6 @@ FixMyStreet::override_config {
                 longitude => -2.943997,
                 name => 'Test Cyclist',
                 severity => 60, # Serious
-                injury_detail => 'Broken shoulder',
                 incident_date => '2014-12-31',
                 incident_time => '14:50',
                 road_type => 'road',
@@ -102,7 +101,6 @@ FixMyStreet::override_config {
         $mech->content_contains( '<h1>Serious incident involving a bicycle and a vehicle</h1>' );
         $mech->content_contains( 'Reported by Test Cyclist at' );
         $mech->content_contains( '(incident occurred: 14:50' );
-        $mech->content_contains( 'Details about injuries: Broken shoulder');
         $mech->content_contains( 'Serious ( incident involved serious injury or hospitalisation )' );
         $mech->content_contains( '<img border="0" src="/cobrands/smidsy/images/pin-vehicle-serious.png"' );
         $mech->content_contains( 'data-map_type="OpenLayers.Layer.Stamen"' );

--- a/templates/web/smidsy/report/new/after_title.html
+++ b/templates/web/smidsy/report/new/after_title.html
@@ -26,11 +26,6 @@
 	</p>
     </div>
 
-    <div class="describe-injury">
-	<label for="form_injury_detail">[% loc('If <em>you</em> were injured, can you tell us more about your injuries?') %]</label>
-	<textarea rows="4" cols="26" name="injury_detail" id="form_injury_detail" class="form-control">[% report.extra.injury_detail | html %]</textarea>
-    </div>
-
     <div class="form_datetime">
 	<label for="form_incident_date">[% loc('When did it happen?') %]</label>
 	<div>

--- a/templates/web/smidsy/report/new/after_title.html
+++ b/templates/web/smidsy/report/new/after_title.html
@@ -2,12 +2,12 @@
 [% MACRO isChecked BLOCK %][% v == exp ? 'checked' : '' %][% END %]   
 [% MACRO isSelected BLOCK %][% v == exp ? 'selected' : '' %][% END %]
 
-    <div class="severity">
+    <fieldset class="severity">
+	<legend>[% loc('How severe was the incident?') %]</legend>
 	[% IF field_errors.severity %]
 	    <p class='form-error'>[% field_errors.severity %]</p>
 	[% END %]
-	<label>[% loc('How severe was the incident?') %]</label>
-	[% v = report.extra.severity || 10 %]
+    [% v = report.extra.severity || 10 %]
 	<p>
 	    <label><input type="radio" name="severity" value="10" [% isChecked(exp=10) %]>
 	    [% loc('No injuries – but it was close!') %]</label>
@@ -24,7 +24,7 @@
 	    <label><input type="radio" name="severity" value="100" [% isChecked(exp=100) %]>
 		[% loc('There were one or more fatalities') %]</label>
 	</p>
-    </div>
+    </fieldset>
 
     <div class="form_datetime">
 	<label for="form_incident_date">[% loc('When did it happen?') %]</label>

--- a/templates/web/smidsy/report/new/after_title.html
+++ b/templates/web/smidsy/report/new/after_title.html
@@ -2,6 +2,29 @@
 [% MACRO isChecked BLOCK %][% v == exp ? 'checked' : '' %][% END %]   
 [% MACRO isSelected BLOCK %][% v == exp ? 'selected' : '' %][% END %]
 
+    <label for="form_participants">[% loc('The incident involved a bike and…?') %]</label>
+    [% IF field_errors.participants %]
+	<p class='form-error'>[% field_errors.participants %]</p>
+    [% END %]
+
+    [% v = report.extra.participants %]
+    <select id="form_participants" name="participants" class="form-control">
+	<option value="car" [% isSelected(exp='car') %]>
+	[% loc('A car') %]</option>
+	<option value="motorcycle" [% isSelected(exp='motorcycle') %]>
+	[% loc('A motorcycle') %]</option>
+	<option value="hgv" [% isSelected(exp='hgv') %]>
+	[% loc('A heavy goods vehicle (HGV)') %]</option>
+	<option value="other" [% isSelected(exp='other') %]>
+	[% loc('Some other vehicle') %]</option>
+	<option value="bicycle" [% isSelected(exp='bicycle') %]>
+	[% loc('Another bike') %]</option>
+	<option value="pedestrian" [% isSelected(exp='pedestrian') %]>
+	[% loc('A pedestrian') %]</option>
+	<option value="generic" [% isSelected(exp='generic') %]>
+	[% loc('Nothing (e.g. street furniture)') %]</option>
+    </select>
+
     <fieldset class="severity">
 	<legend>[% loc('How severe was the incident?') %]</legend>
 	[% IF field_errors.severity %]
@@ -25,6 +48,12 @@
 		[% loc('There were one or more fatalities') %]</label>
 	</p>
     </fieldset>
+
+    <div class="report-to-police form-box" role="alert" style="display: none">
+        <p id="oh-no"><strong>Oh no! We hope you’re OK.</strong></p>
+        <p>As well as using this form to notify the local council, we <strong>strongly</strong> recommend you also report your incident to the police.</p>
+        <p>We’ll give you a direct link to the local police force’s reporting form after confirmation.</p>
+    </div>
 
     <div class="form_datetime">
 	<label for="form_incident_date">[% loc('When did it happen?') %]</label>
@@ -60,27 +89,4 @@
 	    [% loc('Segregated bike path') %]</option>
 	<option value="pavement" [% isSelected(exp='pavement') %]>
 	    [% loc('Pavement') %]</option>
-    </select>
-
-    <label for="form_participants">[% loc('The incident involved a bike and…?') %]</label>
-    [% IF field_errors.participants %]
-	<p class='form-error'>[% field_errors.participants %]</p>
-    [% END %]
-
-    [% v = report.extra.participants %]
-    <select id="form_participants" name="participants" class="form-control">
-	<option value="car" [% isSelected(exp='car') %]>
-	[% loc('A car') %]</option>
-	<option value="motorcycle" [% isSelected(exp='motorcycle') %]>
-	[% loc('A motorcycle') %]</option>
-	<option value="hgv" [% isSelected(exp='hgv') %]>
-	[% loc('A heavy goods vehicle (HGV)') %]</option>
-	<option value="other" [% isSelected(exp='other') %]>
-	[% loc('Some other vehicle') %]</option>
-	<option value="bicycle" [% isSelected(exp='bicycle') %]>
-	[% loc('Another bike') %]</option>
-	<option value="pedestrian" [% isSelected(exp='pedestrian') %]>
-	[% loc('A pedestrian') %]</option>
-	<option value="generic" [% isSelected(exp='generic') %]>
-	[% loc('Nothing (e.g. street furniture)') %]</option>
     </select>

--- a/templates/web/smidsy/report/new/form_heading.html
+++ b/templates/web/smidsy/report/new/form_heading.html
@@ -1,3 +1,0 @@
-<p>You <strong>must ALSO</strong> report ALL injuries and SOME cases involving damage
-    to the police under <a href="http://content.met.police.uk/Article/Collision-forms-and-reports/1400005513174/1400005513174">Section 170 of the Road Traffic Act 1988</a></p>
-</p>

--- a/templates/web/smidsy/tokens/confirm_problem.html
+++ b/templates/web/smidsy/tokens/confirm_problem.html
@@ -1,0 +1,62 @@
+[% INCLUDE 'header.html', bodyclass = 'fullwidthpage', title = loc('Confirmation') %]
+[% SET s = c.cobrand.get_severity(report.extra.severity) %]
+
+<div class="confirmation-header">
+
+    <h1>
+        <a href="[% c.cobrand.base_url_for_report( report ) %][% report.url %]">Thank you for reporting this incident</a>
+    </h1>
+    <h2>
+        Reports like this will help campaigners and planners improve cycling safety across the UK.
+    </h2>
+
+  [% IF s.value > 10 && report.extra.participants.match('(car|motorcycle|hgv|other)') %]
+    [%~ SET police = c.cobrand.get_police_info(report) %]
+    <p>
+      [% IF report.bodies_str %]
+        We’ve forwarded your report on to the local council, but <strong>since
+        this incident involved a vehicle and resulted in an injury</strong>,
+        we strongly recommend you also report it to the local police.
+      [% ELSE %]
+        <strong>since this incident involved a vehicle and resulted in an
+        injury</strong>, we strongly recommend you also report it to the
+        local police.
+      [% END %]
+    </p>
+      [% IF police %]
+        <p class="confirmation-header__cta">
+            <a href="[% police.url %]" class="btn btn-primary">Report it to [% police.name %]</a>
+        </p>
+      [% END %]
+    <h4>Why report it?</h4>
+    <p class="confirmation-header__more" style="font-size: 1em; line-height: 1.5">
+        Drivers who cause injury or damage must either stop and exchange
+        details with the other parties involved, or report the incident to
+        the police. If they don’t, they’re in breach of
+        <a href="http://www.legislation.gov.uk/ukpga/1988/52/section/170">
+        Section 170 of the Road Traffic Act 1988</a>.
+    </p>
+    <p class="confirmation-header__more" style="font-size: 1em; line-height: 1.5">
+        The police will often also want to know more about the incident—including
+        video or photo evidence, if you have it—to determine whether the driver
+        could be charged with a dangerous driving offence.
+    </p>
+
+  [% ELSE %]
+    [% IF report.bodies_str %]
+    <p>
+        We’ve forwarded your report on to the local council, who might get in
+        touch with you for more details.
+    </p>
+    [% END %]
+    <p>
+        You can also take a hand in making your own local roads safer by
+        <a href="https://www.cyclinguk.org/groups-listing">joining your
+        local cycling campaign</a>.
+    </p>
+
+  [% END %]
+
+</div>
+
+[% INCLUDE 'footer.html' %]

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -24,6 +24,14 @@ select, input, textarea {
   max-width: none;
 }
 
+ // match label styling
+legend {
+  display: block;
+  margin-top: 1.25em;
+  margin-bottom: 0.5em;
+  font-weight: bold;
+}
+
 div.form_datetime {
     overflow: auto;
 

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -407,6 +407,23 @@ dt:target {
     }
 }
 
+.confirmation-header {
+  h4 {
+    font-size: 1.2em;
+    font-weight: bold;
+  }
+}
+
+p.confirmation-header__cta {
+  font-size: 1.1em; // down slightly from 1.2em, because we want a slightly smaller button
+  margin: 1.5em 0 2em 0; // vertical margin to make the button stand out
+}
+
+p.confirmation-header__more {
+  font-size: 1em; // down from 1.2em for regular paragraphs
+  line-height: 1.5;
+}
+
 // mySociety standard footer bits
 $mysoc-footer-background-color: $color-neutral-slategrey;
 $mysoc-footer-text-color: mix(#fff, $color-neutral-slategrey, 50%);

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -61,13 +61,17 @@ div.form_datetime {
             margin-top: 0;
         }
     }
+
+    .report-to-police {
+        background-color: $color-neutral-cream;
+
+        & > :last-child {
+            margin-bottom: 0;
+        }
+    }
 }
 
 .severity {
-    label {
-        margin-top: 0;
-    }
-
     p {
         margin-bottom: 0.5em;
 
@@ -77,6 +81,7 @@ div.form_datetime {
 
         label {
             font-weight: normal;
+            margin-top: 0;
         }
 
         input {

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -32,22 +32,6 @@ $(function() {
         fixmystreet.markers.refresh( { force: true } );
     });
 
-    $('input[name="severity"]').on('change', function(){
-        // Assumes the severity radio buttons have numeric values,
-        // where a value over 10 implies injury.
-        if( ($('#mapForm input[name="severity"]:checked').val() -0) > 10) {
-            $('.describe-injury').slideDown();
-        } else {
-            $('.describe-injury').slideUp(
-                // slideUp doesn't happen if element already hidden.
-                // But it does call callback so hide when complete.
-                // (We hide on callback, to avoid the hide killing the slide
-                // animation entirely.)
-                function () { $(this).hide() }
-            );
-        }
-    }).change(); // and call on page load
-
     var type = $('form.statistics-filter input[name=type]');
     type.on('change', function () {
         var val = $(this).val();

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -32,6 +32,36 @@ $(function() {
         fixmystreet.markers.refresh( { force: true } );
     });
 
+    var involvedInjury = function involvedInjury() {
+        // Assumes the severity radio buttons have numeric values,
+        // where a value over 10 implies injury.
+        return ( $('input[name="severity"]:checked').val() - 0 ) > 10
+    };
+
+    var involvedFatality = function involvedFatality() {
+        return ( $('input[name="severity"]:checked').val() - 0 ) >= 100;
+    };
+
+    var involvedVehicle = function involvedVehicle() {
+        var vehicles = ["car", "motorcycle", "hgv", "other"];
+        return $.inArray($('select[name="participants"]').val(), vehicles) > -1;
+    };
+
+    var shouldContactPolice = function shouldContactPolice() {
+        return involvedInjury() && involvedVehicle();
+    };
+
+    $('input[name="severity"], select[name="participants"]').on('change', function(){
+        $('#oh-no').toggle(!involvedFatality());
+
+        if ( shouldContactPolice() ) {
+            $('.report-to-police').slideDown();
+        } else {
+            // slideUp doesn't happen if element already hidden.
+            $('.report-to-police').slideUp();
+        }
+    }).change(); // and call on page load
+
     var type = $('form.statistics-filter input[name=type]');
     type.on('change', function () {
         var val = $(this).val();

--- a/web/cobrands/smidsy/layout.scss
+++ b/web/cobrands/smidsy/layout.scss
@@ -223,6 +223,10 @@ body.mappage {
         }
     }
 
+    .report-to-police {
+        background-color: $color-neutral-cream;
+    }
+
     input[type=file]{
       background: transparent;
     }


### PR DESCRIPTION
Moves the message about reporting to the police, closer to the input field where it's more likely to be seen:

![aug-20-2018 15-48-26](https://user-images.githubusercontent.com/739624/44347741-88131d00-a490-11e8-8480-86de6b05e011.gif)

As well as improving the report confirmation screen to reiterate reporting the incident to the police (if the user indicated the incident resulted in injuries):

<img width="583" alt="image" src="https://user-images.githubusercontent.com/4776/44163473-778f2b00-a0bb-11e8-8965-37d64f4a0e4c.png">

The button takes the user to a Google search (prefilled with the rough location of the report) to find the appropriate police force to contact.

Connects to #13.