### PR TITLE
Prevent double gutter either side of page content

### DIFF
--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -421,7 +421,7 @@ $mysoc-footer-legal-text-color: mix(#fff, $color-neutral-slategrey, 50%);
 $mysoc-footer-image-path: '/cobrands/smidsy/images/mysoc-footer-dark/';
 $mysoc-footer-breakpoint-sm: 48em;
 
-$grid-max-width: 60em;
+$grid-max-width: 62em;
 $grid-gutter: 2em;
 $grid-breakpoint-sm: $mysoc-footer-breakpoint-sm;
 

--- a/web/cobrands/smidsy/layout.scss
+++ b/web/cobrands/smidsy/layout.scss
@@ -52,12 +52,6 @@ body {
   }
 }
 
-.content {
-  @include box-shadow(none);
-  margin-left: 15px; // to match nav items
-  margin-right: 15px; // to match nav items
-}
-
 .mysoc-footer {
   // The below lines are so that on e.g. /faq the footer will move on
   // top of the fixed sidebar in narrow height situations.
@@ -277,6 +271,7 @@ body.twothirdswidthpage {
         background-color: $color-neutral-raincloud;
         width: 15em;
         padding: 0;
+        margin: 0;
 
         aside {
           box-shadow: none;


### PR DESCRIPTION
# Before

![before](https://user-images.githubusercontent.com/739624/44531916-cce5c080-a6e9-11e8-9cf5-a051b3ed37bd.png)

# After

![after](https://user-images.githubusercontent.com/739624/44531925-cfe0b100-a6e9-11e8-8bde-00971c3517e7.png)
