### PR TITLE
A couple of JavaScript improvements

### DIFF
--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -1,9 +1,11 @@
-fixmystreet.maps.marker_size = function() {
-    return 'normal';
-};
-fixmystreet.maps.selected_marker_size = function() {
-    return 'big';
-};
+if (fixmystreet.maps) {
+    fixmystreet.maps.marker_size = function() {
+        return 'normal';
+    };
+    fixmystreet.maps.selected_marker_size = function() {
+        return 'big';
+    };
+}
 
 if (stats19_box = document.getElementById('show_stats19_checkbox')) {
     // Override the protocol initialize to include stats19 toggle


### PR DESCRIPTION
* Checks for the presence of `fixmystreet.maps` before trying to access it (since it’s only present on map pages)
* Stops injecting jquery into the `scripts` array, since core already puts it in there on all the pages that matter.