### PR TITLE
WIP minimally working report now front page button

### DIFF
--- a/templates/email/smidsy/partial.html
+++ b/templates/email/smidsy/partial.html
@@ -1,0 +1,73 @@
+[%
+
+email_summary = "Complete your report on " _ site_name;
+email_columns = 1;
+
+PROCESS '_email_settings.html';
+
+h2_style = 'margin: 0 0 15px 0; font-size: 21px; line-height: 26px';
+td_number_style = 'padding-right: 10px; font-size: 21px; line-height: 26px; font-weight: bold; vertical-align: top;';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% only_column_style %]">
+  <h1 style="[% h1_style %]">Thanks for beginning a report on [% site_name %]</h1>
+  <p style="[% p_style %]">
+    We know it can be stressful dealing with the aftermath of a cycling
+    collision or near-miss, so here’s a quick run down of what you should
+    do next, in your own time:
+  </p>
+  <table [% table_reset %]>
+    <tr>
+      <th style="[% td_style %] [% td_number_style %] padding-top: 10px;">1.</th>
+      <th style="[% td_style %] padding-top: 10px;">
+        <h2 style="[% h2_style %]">
+          Complete your report using this link
+        </h2>
+        <p style="margin: 15px 0;">
+          <a style="[% button_style %]" href="[% token_url %]">Complete report</a>
+        </p>
+        <p style="[% p_style %]">
+            Your report will be sent to the local council, who will often use
+            it when planning infrastructure changes and eductional programmes.
+            Plus it’ll become part of the public [% site_name %] incident
+            dataset, used by planners and campaigners around the UK.
+        </p>
+      </th>
+    </tr>
+    <tr>
+      <th style="[% td_style %] [% td_number_style %] padding-top: 10px;">2.</th>
+      <th style="[% td_style %] padding-top: 10px;">
+        <h2 style="[% h2_style %]">
+          Report injuries to the Police
+        </h2>
+        <p style="[% p_style %]">
+          If your incident involved a motor vehicle and any sort of injury
+          or damage to property, you should also report it to the Police,
+          using the link we’ll send to you, once you’ve completed your
+          [% site_name %] report.
+        </p>
+        <p style="[% p_style %]">
+          Hopefully the driver of the vehicle will already have reported
+          the incident, but if they haven’t, your report will help the
+          Police investigate a possible offence under Section 170 of the
+          Road Traffic Act.
+        </p>
+      </th>
+    </tr>
+  </table>
+  <hr style="border: none; border-top: 1px solid #ccc; margin: 20px 0;">
+  <p>
+    By reporting collisions and near-misses like yours, you’re helping us build
+    the evidence base for cycle safety improvements, together. Completing your
+    report will only take a few minutes, but will contribute a huge amount to
+    our cause:
+  </p>
+  <p style="margin: 20px 0;">
+    <a style="[% button_style %]" href="[% token_url %]">Complete report</a>
+  </p>
+</th>
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/smidsy/partial.txt
+++ b/templates/email/smidsy/partial.txt
@@ -1,0 +1,37 @@
+Subject: Complete your report on [% site_name %]
+
+Hello [% report.name || report.email %],
+
+Thanks for beginning a report on [% site_name %]. We know it can be stressful
+dealing with the aftermath of a cycling collision or near-miss, so here’s a
+quick run down of what you should do next, in your own time:
+
+1. Complete your report on [% site_name %] using this link:
+
+   [% token_url %]
+
+   Your report will be sent to the local council, who will often use it when
+   planning infrastructure changes and eductional programmes. Plus it’ll become
+   part of the public [% site_name %] incident dataset, used by planners and
+   campaigners around the UK.
+
+2. If your incident involved a motor vehicle and any sort of injury or damage
+   to property, you should also report it to the Police, using the link we’ll
+   send to you, once you’ve completed your [% site_name %] report.
+
+   Hopefully the driver of the vehicle will already have reported the incident,
+   but if they haven’t, your report will help the Police investigate a possible
+   offence under Section 170 of the Road Traffic Act.
+
+By reporting collisions and near-misses like yours, you’re helping us build the
+evidence base for cycle safety improvements, together. Completing your report
+will only take a few minutes, but will contribute a huge amount to our cause:
+
+   [% token_url %]
+
+Thank you,
+
+[% signature %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.

--- a/templates/web/smidsy/header_site.html
+++ b/templates/web/smidsy/header_site.html
@@ -1,0 +1,30 @@
+[% IF bodyclass.match('frontpage') %]
+    <div id="report-now">
+        <svg width="60" height="53" viewBox="0 0 60 53" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M56 53a4 4 0 0 0 3.5-6l-26-45a4 4 0 0 0-6.9 0L.6 47A4 4 0 0 0 4 53h52z" fill="#EC1D24"/><path fill="#FFF" d="M53.6 47.6H6.3l23.6-41z"/><path d="M30 16c-2.5 0-4.6 1.9-4.6 4.4 0 .7.2 1.1.2 1.1L29.4 37h1l4-15.5.1-1c0-2.6-2.1-4.6-4.6-4.6zM30 45.8a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z" fill="#000" fill-rule="nonzero"/></g></svg>
+        <p>Tap here to report a cycling incident or near-miss that’s just
+        happened, and we’ll email you later with guidance on what to do.</p>
+    </div>
+    <form action="/import" method="POST" id="report-now-form">
+        <input type="hidden" name="web" value="1">
+        <input id="report-now-latitude" type="hidden" name="lat">
+        <input id="report-now-longitude" type="hidden" name="lon">
+        <input type="hidden" name="subject" value="report now">
+        <input type="hidden" name="service" value="front-button">
+        <p>
+            <label for="form_name">Name</label>
+            <input id="form_name" type="text" name="name" class="form-control required" required>
+        </p>
+        <p>
+            <label for="form_email">Email</label>
+            <input id="form_email" type="email" name="email" class="form-control required" required>
+        </p>
+        <input class="btn" id="form_submit" type="submit" value="Set reminder">
+    </form>
+[% END %]
+
+<header id="site-header" role="banner">
+    <div class="container">
+        [% INCLUDE 'header_logo.html' %]
+        <a href="#main-nav" id="nav-link">Main Navigation</a>
+    </div>
+</header>

--- a/templates/web/smidsy/index.html
+++ b/templates/web/smidsy/index.html
@@ -1,6 +1,9 @@
 [% pre_container_extra = PROCESS 'around/postcode_form.html' %]
 [% SET bodyclass = 'frontpage fullwidthpage' %]
 [% INCLUDE 'header.html', title = '' %]
+[% extra_js = [
+    version('/cobrands/smidsy/js/front-page.js'),
+] -%]
 
 [% IF error %]
     <p class="form-error">[% error %]</p>

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -231,6 +231,63 @@ body.twothirdswidthpage {
   }
 }
 
+#report-now,
+#report-now-form {
+  display: none; // will be shown later
+  padding: 1em;
+  color: #000;
+  background-color: #FFDC59; // brighter version of $color-primary-orange
+}
+
+#report-now {
+  position: relative;
+  cursor: pointer;
+
+  .js & {
+    display: block;
+  }
+
+  svg {
+    width: 60px;
+    height: 53px;
+    position: absolute;
+    left: 1em;
+    top: 50%;
+    margin-top: (53px / 2 * -1);
+  }
+
+  p {
+    font-size: 0.875em;
+    line-height: 1.3;
+    margin: 0 0 0 80px;
+  }
+}
+
+#report-now-form {
+  padding-top: 0;
+
+  label {
+    margin-top: 0;
+    line-height: 1;
+  }
+
+  p {
+    margin-bottom: 1em;
+  }
+
+  .btn {
+    width: 100%;
+    background: $color-primary-blue;
+    color: #fff !important;
+    text-shadow: 0 1px 1px rgba(0,0,0,0.5);
+    border: none;
+
+    &:hover {
+      background: darken($color-primary-blue, 10%);
+    }
+  }
+}
+
 .front__how-it-works,
 .front__data {
   text-align: center;

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -111,15 +111,17 @@ body.twothirdswidthpage {
   background-repeat: no-repeat;
   background-position: center top;
   color: #fff;
-  padding: 2em;
+  padding: 1em;
 
   h1, p, label, #geolocate_link {
     text-shadow: 0 1px 1px rgba(#000, 0.5), 0 0 20px #000;
   }
 
   h1 {
+    font-size: 2em;
     line-height: 1.2;
     margin: 0 auto 0.5em auto;
+    max-width: 7em; // break nicely onto two lines
   }
 
   p {
@@ -127,21 +129,23 @@ body.twothirdswidthpage {
   }
 
   p.lead {
-    font-size: 1.5em;
+    font-size: 1.2em;
     line-height: 1.2;
-    margin: 0 auto 0.5em auto;
+    margin: 0 auto;
     max-width: 24em;
   }
 
   #postcodeForm {
+    padding: 1em 0 0.5em 0;
     margin: 0; // override ".full-width" negative horizontal margins
     background: transparent;
     color: inherit;
 
     label {
       color: inherit;
-      margin: 0.5em 0 16px 0;
-      font-size: 21px;
+      margin: 0 0 0.5em 0;
+      font-size: 1.2em;
+      line-height: 1.2;
     }
 
     div {

--- a/web/cobrands/smidsy/js/front-page.js
+++ b/web/cobrands/smidsy/js/front-page.js
@@ -1,0 +1,35 @@
+var fixmystreet = fixmystreet || {};
+
+(function(){
+    var link = document.getElementById('report-now');
+    var form = document.getElementById('report-now-form');
+    if (!link) { return; }
+    var https = window.location.protocol.toLowerCase() === 'https:';
+    if ('geolocation' in navigator && https && window.addEventListener && fixmystreet.geolocate) {
+        fixmystreet.geolocate(link, function(pos) {
+            var latitude = pos.coords.latitude.toFixed(6);
+            var longitude = pos.coords.longitude.toFixed(6);
+            form.style.display = 'block';
+            var lat_input = document.getElementById('report-now-latitude');
+            lat_input.value = latitude;
+            var long_input = document.getElementById('report-now-longitude');
+            long_input.value = longitude;
+        });
+
+        var submit = document.getElementById('form_submit');
+        submit.addEventListener('click', function(e) {
+            var name = document.getElementById('form_name');
+            var email = document.getElementById('form_email');
+
+            if (name.value === '' ) {
+                name.className += ' invalid';
+            }
+            if (email.value === '' ) {
+                email.className += ' invalid';
+            }
+        });
+    } else {
+        form.style.display = 'none';
+        link.style.display = 'none';
+    }
+})();

--- a/web/cobrands/smidsy/layout.scss
+++ b/web/cobrands/smidsy/layout.scss
@@ -350,6 +350,11 @@ body.twothirdswidthpage {
   }
 }
 
+#report-now,
+#report-now-form {
+    display: none !important;
+}
+
 .front__how-it-works,
 .front__data {
   h2 {

--- a/web/cobrands/smidsy/layout.scss
+++ b/web/cobrands/smidsy/layout.scss
@@ -301,6 +301,7 @@ body.twothirdswidthpage {
 
   h1 {
     font-size: 38px;
+    max-width: none;
   }
 
   p.lead {
@@ -309,6 +310,10 @@ body.twothirdswidthpage {
 
   #postcodeForm {
     padding-bottom: 1em;
+
+    label {
+      font-size: 1.5em;
+    }
 
     div {
       width: 500px;


### PR DESCRIPTION
Fixes #27.

Adds a clickable banner to the top of the homepage, which is only visible 1) on narrow screens and 2) when javascript is available.

Tapping the banner opens up a simplified reporting form. Submitting the form (to `/import`) sets it to be automatically followed up later, aparently.

**TO-DO**

- [x] Check the `/import` endpoint does what we think it does.
- [x] Add a customised version of the `templates/email/default/partial.txt` email.
- [x] Add a HTML version of the email.

## How it looks on a smallish (eg: iPhone 5/SE) screen

<img src="https://user-images.githubusercontent.com/739624/46093782-2b520300-c1b0-11e8-8c64-d538f6fc3a12.png" width="320" height="568" alt="">

## How it looks once it’s tapped

<img src="https://user-images.githubusercontent.com/739624/46093810-445ab400-c1b0-11e8-8e94-8e0ce949dade.png" width="320" height="568" alt="">

## How it looks on a larger (eg: iPhone 6/7/8) screen

<img src="https://user-images.githubusercontent.com/739624/46093828-550b2a00-c1b0-11e8-812b-9541b6719c2e.png" width="375" height="667" alt="">