### PR TITLE
Make it clearer that updates aren't sent to the authorities

### DIFF
--- a/templates/web/smidsy/report/_update-form-heading.html
+++ b/templates/web/smidsy/report/_update-form-heading.html
@@ -1,0 +1,1 @@
+<h2>Leave an update for other viewers</h2>

--- a/templates/web/smidsy/report/_updates_disallowed_message.html
+++ b/templates/web/smidsy/report/_updates_disallowed_message.html
@@ -1,3 +1,5 @@
 [% UNLESS problem.external_body == "stats19" OR c.user_exists %]
-    <p><small>If this is your report, log in to leave an update.</small></p>
+    [% INCLUDE 'report/_update-form-heading.html' %]
+    <p>If this is your report, <a href="/auth?r=[% c.req.uri.path %]">you can log in to leave an update</a>.</p>
+    <p>Updates are not sent to the council, but they can be helpful for anyone trying to understand what happened after you reported this incident.</p>
 [% END %]

--- a/templates/web/smidsy/report/updates-sidebar-notes.html
+++ b/templates/web/smidsy/report/updates-sidebar-notes.html
@@ -1,5 +1,3 @@
 <p>
-    <small>Please note that updates are not sent to the highways department.
-    If you leave your name it will be public. Your information will only be used in accordance with our <a href="/faq#privacy">privacy policy</a>
-    </small>
+    Your update <strong>will not</strong> be sent to the highways department, but will be displayed online for other visitors to see. <a href="/faq#privacy">Read our privacy policy</a> for more detail.
 </p>

--- a/web/cobrands/smidsy/layout.scss
+++ b/web/cobrands/smidsy/layout.scss
@@ -259,6 +259,13 @@ body.mappage {
   }
 }
 
+#update_form {
+  // "Updates are not sent to highways dept" message at top of Update form
+  & > .general-notes {
+    font-size: 1em; // up from 0.75em;
+  }
+}
+
 body.twothirdswidthpage {
   .container {
     .content {


### PR DESCRIPTION
Rewording also now respects the fact that you can make your update
anonymous, so your name won’t necessarily be published.

![screen shot 2018-09-13 at 14 57 11](https://user-images.githubusercontent.com/739624/45492872-5296e200-b765-11e8-8d64-1e49df5603f1.png)

Also, the message you see if you’re not logged in is much nicer now, with a link to log in, which returns you back to the report on success.

![screen shot 2018-09-13 at 15 01 17](https://user-images.githubusercontent.com/739624/45493141-0304e600-b766-11e8-9f6a-5bad3986755b.png)

Part of #20.