### PR TITLE
Report editing UI improvements

### DIFF
--- a/bin/make_po
+++ b/bin/make_po
@@ -89,6 +89,13 @@ sub translate {
     $s =~ s/\(like graffiti.*\)/ /;
     $s =~ s/(Please enter your full name).*? -/$1 -/;
 
+    # Quick fixes since anyone can "moderate" their own report on Collidescope.
+    # The "show your name" change might be a bit odd for site admins (who really
+    # *are* moderating other people's reports) but it'll do for now.
+    $s =~ s/\bModerate\b/Edit/g;
+    $s =~ s/\bModerate this report\b/Edit this report/g;
+    $s =~ s/\bShow reporter&rsquo;s name\b/Show your name publicly/g;
+
     $s =~ s{We send it to the council on your behalf}
            {The details will be sent to the local highways department and/or police constabulary};
     $s =~ s/To find out what local alerts we have for you/To find out what local alerts we have in your area, council or ward/;

--- a/templates/web/smidsy/report/_main_after.html
+++ b/templates/web/smidsy/report/_main_after.html
@@ -1,3 +1,9 @@
+<p class="moderate-edit">
+    Your changes <strong>will not</strong> be sent to the highways department, but will be visible online for other visitors, and council staff, to see.
+</p>
+
+<hr class="moderate-edit">
+
 <dl>
     <dt> Severity </dt>
     <dd>

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -428,6 +428,16 @@ p.confirmation-header__more {
   line-height: 1.5;
 }
 
+// Hide moderation reason input, because people can "moderate" (edit)
+// their own reports on Collideoscope, and it's weird asking them to
+// give a reason for their own edits!!
+// This also means the moderation reason won't show up for admins
+// editing *other people's* reports, but we can live with that.
+input[name="moderation_reason"],
+label[for="moderation_reason"] {
+  display: none;
+}
+
 // mySociety standard footer bits
 $mysoc-footer-background-color: $color-neutral-slategrey;
 $mysoc-footer-text-color: mix(#fff, $color-neutral-slategrey, 50%);


### PR DESCRIPTION
Now that Collideoscope users can "moderate" their own reports, we use the word "Edit" instead, and also hide the moderation reason input, since it’s of no use to them.

Fixes #30.