### PR TITLE
Add heatmap layer to map

### DIFF
--- a/bin/create-cobrand-symlinks
+++ b/bin/create-cobrand-symlinks
@@ -22,6 +22,7 @@ echo "Creating symlinks in $PARENT:"
 
 ln $LN_FLAGS $PARENT/collideoscope/locale/en_GB.UTF-8/LC_MESSAGES/Smidsy.po $FMS/locale/en_GB.UTF-8/LC_MESSAGES/
 ln $LN_FLAGS $PARENT/collideoscope/perllib/FixMyStreet/Cobrand/Smidsy.pm $FMS/perllib/FixMyStreet/Cobrand/
+ln $LN_FLAGS $PARENT/collideoscope/perllib/FixMyStreet/Map/Smidsy.pm $FMS/perllib/FixMyStreet/Map/
 ln $LN_FLAGS $PARENT/collideoscope/templates/web/smidsy $FMS/templates/web/
 ln $LN_FLAGS $PARENT/collideoscope/templates/email/smidsy $FMS/templates/email/
 ln $LN_FLAGS $PARENT/collideoscope/web/cobrands/smidsy $FMS/web/cobrands/

--- a/perllib/FixMyStreet/Map/Smidsy.pm
+++ b/perllib/FixMyStreet/Map/Smidsy.pm
@@ -1,0 +1,18 @@
+# FixMyStreet::Map::Smidsy
+# More JavaScript, for heatmap WFS layer
+
+package FixMyStreet::Map::Smidsy;
+use base 'FixMyStreet::Map::OSM::TonerLite';
+
+use strict;
+
+sub map_javascript { [
+    '/vendor/OpenLayers/OpenLayers.wfs.js',
+    "https://stamen-maps.a.ssl.fastly.net/js/tile.stamen.js?v1.3.0",
+    '/js/map-OpenLayers.js',
+    '/js/map-toner-lite.js',
+    '/cobrands/fixmystreet/assets.js',
+    '/cobrands/smidsy/js/assets.js',
+] }
+
+1;

--- a/web/cobrands/smidsy/js/assets.js
+++ b/web/cobrands/smidsy/js/assets.js
@@ -1,0 +1,73 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+var heatmap_style = new OpenLayers.Style({}, {
+    context: {
+        getStrokeColor: function(feature) {
+            // "density" is incidents-per-metre for this road feature
+            var density = parseFloat(feature.attributes.density);
+            if (density < 0.001) {
+                return "#fff5eb";
+            } else if (density < 0.01) {
+                return "#fed2a6";
+            } else if (density < 0.1) {
+                return "#fd9243";
+            } else if (density < 1) {
+                return "#df4f05";
+            } else {
+                return "#7f2704";
+            }
+        },
+        getStrokeWidth: function() {
+            return {
+                13: 2,
+                14: 3,
+                15: 5,
+                16: 8,
+                17: 12,
+                18: 16
+            }[fixmystreet.map.zoom + fixmystreet.zoomOffset];
+        }
+    }
+});
+heatmap_style.addRules([new OpenLayers.Rule({
+    symbolizer: {
+        strokeColor: '${getStrokeColor}',
+        strokeLinecap: 'butt',
+        strokeWidth: '${getStrokeWidth}',
+        strokeOpacity: 0.9
+    }
+})]);
+
+
+fixmystreet.assets.add({
+    http_options: {
+        url: "https://tilma.staging.mysociety.org/mapserver/collideoscope",
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::3857",
+            TYPENAME: "heatmap",
+            SORTBY: "density A"
+        }
+    },
+    format_class: OpenLayers.Format.GML.v3.MultiCurveFix,
+    asset_type: 'spot',
+    stylemap: new OpenLayers.StyleMap({
+        'default': heatmap_style
+    }),
+    max_resolution: 19.109257068634033,
+    min_resolution: 0.5971642833948135,
+    non_interactive: true,
+    geometryName: 'msGeometry',
+    srsName: "EPSG:3857",
+    strategy_class: OpenLayers.Strategy.FixMyStreet,
+    name: "Heatmap",
+    always_visible: true
+});
+
+})();

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -106,20 +106,40 @@ $(function() {
         $("#filter_categories").val(categories).trigger("change");
     });
 
-    if ($("#sub_map_links").length && fixmystreet.map && fixmystreet.map.getLayersByName("Heatmap").length) {
-        var layer = fixmystreet.map.getLayersByName("Heatmap")[0];
-        var label = layer.getVisibility() ? "Hide heatmap" : "Show heatmap";
-        var $a = $("<a href='#'></a>").text(label).click(function() {
-            if (layer.getVisibility()) {
-                $a.text("Show heatmap");
-                layer.setVisibility(false);
-            } else {
-                $a.text("Hide heatmap");
-                layer.setVisibility(true);
-            }
-            return false;
-        });
-        $a.appendTo("#sub_map_links");
-    }
+    if (fixmystreet.map) {
+        var layer;
+        if (fixmystreet.page === "reports" && !fixmystreet.map.getLayersByName("Heatmap").length) {
+            layer = fixmystreet.assets.layers[0];
+            if (layer && layer.name === "Heatmap") {
+                fixmystreet.map.addLayer(layer);
 
+                // Don't cover the existing pins layer
+                var pins_layer = fixmystreet.map.getLayersByName("Pins")[0];
+                if (pins_layer) {
+                    layer.setZIndex(pins_layer.getZIndex()-1);
+                }
+            }
+        }
+
+        if ($("#sub_map_links").length && fixmystreet.map.getLayersByName("Heatmap").length) {
+            layer = fixmystreet.map.getLayersByName("Heatmap")[0];
+            var label = layer.getVisibility() ? "Hide heatmap" : "Show heatmap";
+            var $a = $("<a href='#'></a>").text(label).click(function() {
+                if (layer.getVisibility()) {
+                    $a.text("Show heatmap");
+                    layer.setVisibility(false);
+                } else {
+                    $a.text("Hide heatmap");
+                    layer.setVisibility(true);
+                }
+                return false;
+            });
+            $a.appendTo("#sub_map_links");
+            fixmystreet.map.events.register("zoomend", layer, function() {
+                $a.toggle(this.inRange);
+            });
+            $a.toggle(layer.inRange);
+
+        }
+    }
 });

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -106,4 +106,20 @@ $(function() {
         $("#filter_categories").val(categories).trigger("change");
     });
 
+    if ($("#sub_map_links").length && fixmystreet.map && fixmystreet.map.getLayersByName("Heatmap").length) {
+        var layer = fixmystreet.map.getLayersByName("Heatmap")[0];
+        var label = layer.getVisibility() ? "Hide heatmap" : "Show heatmap";
+        var $a = $("<a href='#'></a>").text(label).click(function() {
+            if (layer.getVisibility()) {
+                $a.text("Show heatmap");
+                layer.setVisibility(false);
+            } else {
+                $a.text("Hide heatmap");
+                layer.setVisibility(true);
+            }
+            return false;
+        });
+        $a.appendTo("#sub_map_links");
+    }
+
 });


### PR DESCRIPTION
Adds a collision heatmap (provided as a WFS layer) to the map:

<img width="1392" alt="screen shot 2018-09-17 at 09 35 57" src="https://user-images.githubusercontent.com/4776/45613109-1a411d80-ba5d-11e8-8c12-a03342b545a7.png">

![file](https://user-images.githubusercontent.com/4776/45613297-c125b980-ba5d-11e8-999b-361ce8281d4b.jpg)

Fixes #25.