### PR TITLE
Brighter heatmap colours

### DIFF
--- a/web/cobrands/smidsy/js/assets.js
+++ b/web/cobrands/smidsy/js/assets.js
@@ -10,15 +10,15 @@ var heatmap_style = new OpenLayers.Style({}, {
             // "density" is incidents-per-metre for this road feature
             var density = parseFloat(feature.attributes.density);
             if (density < 0.001) {
-                return "#fff5eb";
+                return "#b0a284";
             } else if (density < 0.01) {
-                return "#fed2a6";
+                return "#cea44b";
             } else if (density < 0.1) {
-                return "#fd9243";
+                return "#ffae00";
             } else if (density < 1) {
-                return "#df4f05";
+                return "#ff6c00";
             } else {
-                return "#7f2704";
+                return "#ff0000";
             }
         },
         getStrokeWidth: function() {


### PR DESCRIPTION
I couldn’t get the heatmap working locally, so maybe @davea can try this out and send me some screenshots of how it looks with real data?

The idea is that:

1. The high end of the density scale is a brighter red, to make "hotspots" stand out a bit more.
1. The next two steps are bright orange and bright yellow, so they’re still quite visible.
1. Then the final two steps are shades of that yellow, fading into the grey of the roads behind them (rather than fading to white, as before, which was making the roads disappear).

Here’s a mockup of the before and after, in Photoshop:

![colours](https://user-images.githubusercontent.com/739624/45631835-bab23480-ba93-11e8-950c-074a2ce18756.gif)
