### PR TITLE
Reinstate "Sign in" / "Your account" nav menu items

### DIFF
--- a/templates/web/smidsy/main_nav_items.html
+++ b/templates/web/smidsy/main_nav_items.html
@@ -2,3 +2,8 @@
 [%~ INCLUDE navitem uri='/reports' label='Statistics' ~%]
 [%~ INCLUDE navitem uri='/faq' label=loc('Help') ~%]
 [%~ INCLUDE navitem uri='/about/sponsors' label=loc('Sponsors') ~%]
+[%~ IF c.user_exists ~%]
+    [%~ INCLUDE navitem uri='/my' label=loc('Your account') ~%]
+[%~ ELSE ~%]
+    [%~ INCLUDE navitem uri='/auth' label=loc('Sign in') ~%]
+[%~ END ~%]


### PR DESCRIPTION
At least now there’s a hint of somewhere to go if you want to sign out!

![screenshot_2018-09-26 collideoscope 1](https://user-images.githubusercontent.com/739624/46073824-e0b79300-c17d-11e8-8c0e-f9f84c7aad34.png)

![screenshot_2018-09-26 collideoscope](https://user-images.githubusercontent.com/739624/46073819-deedcf80-c17d-11e8-99f8-02989e5eabf2.png)

Fixes #73.

