### PR TITLE
Add constituencies to /reports dropdown

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Smidsy.pm
+++ b/perllib/FixMyStreet/Cobrand/Smidsy.pm
@@ -522,6 +522,7 @@ sub report_page_data {
         my $rs = $c->stash->{objects_rs};
         if ($area =~ s/^WMC://) {
             $c->stash->{area} = $area;
+            $c->stash->{area_body_name} = $areas->{$area}->{name};
             $c->stash->{objects_rs} = $rs->search( areas => { 'like', '%,' . $area . ',%' } );
         } elsif (my $body = $c->get_param('area_body') and $area ne 'wards') {
             $c->stash->{area_body} = $body;

--- a/templates/web/smidsy/reports/index.html
+++ b/templates/web/smidsy/reports/index.html
@@ -34,16 +34,29 @@
             <select class="form-control" id="area" name="area">
                 <option value="">All areas</option>
                 [% IF area_body %]
-                <option value="wards"[% ' selected' IF area == area_body OR area == 'wards' %]>All wards</option>
-                [% FOR ward IN children.sort('name') %]
-                <option value="[% ward.id %]"[% ' selected' IF ward.id == area %]>[% ward.name | html ~%]</option>
-                [% END %]
+                    <option value="wards"[% ' selected' IF area == area_body OR area == 'wards' %]>All wards</option>
+                    [% FOR ward IN children.sort('name') %]
+                        <option value="[% ward.id %]"[% ' selected' IF ward.id == area %]>[% ward.name | html ~%]</option>
+                    [% END %]
                 [% ELSE %]
-                [% FOR b IN bodies # Not body as 'body' may be on stash %]
-                <option value="[% b.id %]"[% ' selected' IF b.id == area %]>[% b.name | html ~%]
-                    [% IF NOT b.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
-                </option>
-                [% END %]
+                    [% IF constituencies %]
+                        <optgroup label="Councils">
+                    [% END %]
+                    [% FOR b IN bodies # Not body as 'body' may be on stash %]
+                        <option value="[% b.id %]"[% ' selected' IF b.id == area %]>[% b.name | html ~%]
+                            [% IF NOT b.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
+                        </option>
+                    [% END %]
+                    [% IF constituencies %]
+                        </optgroup>
+                        <optgroup label="Constituencies">
+                            [% FOR constituency IN constituencies %]
+                                <option value="WMC:[% constituency.id %]"[% ' selected' IF constituency.id == area %]>
+                                    [% constituency.name | html ~%]
+                                </option>
+                            [% END %]
+                        </optgroup>
+                    [% END %]
                 [% END %]
             </select>
         </p>

--- a/templates/web/smidsy/reports/index.html
+++ b/templates/web/smidsy/reports/index.html
@@ -31,7 +31,7 @@
             <input type="hidden" name="area_body" value="[% area_body | html %]">
             [% END %]
             <label for="area">[% loc('Incidents reported in:') %]</label>
-            <select class="form-control" id="area" name="area">
+            <select class="form-control js-autocomplete" id="area" name="area">
                 <option value="">All areas</option>
                 [% IF area_body %]
                     <option value="wards"[% ' selected' IF area == area_body OR area == 'wards' %]>All wards</option>
@@ -44,7 +44,7 @@
                     [% END %]
                     [% FOR b IN bodies # Not body as 'body' may be on stash %]
                         <option value="[% b.id %]"[% ' selected' IF b.id == area %]>[% b.name | html ~%]
-                            [% IF NOT b.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
+                            [%~ IF NOT b.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
                         </option>
                     [% END %]
                     [% IF constituencies %]
@@ -52,7 +52,7 @@
                         <optgroup label="Constituencies">
                             [% FOR constituency IN constituencies %]
                                 <option value="WMC:[% constituency.id %]"[% ' selected' IF constituency.id == area %]>
-                                    [% constituency.name | html ~%]
+                                    [%~ constituency.name | html ~%]
                                 </option>
                             [% END %]
                         </optgroup>


### PR DESCRIPTION
This PR adds constituencies as an `optgroup` after councils in the dropdown:

![wmc](https://user-images.githubusercontent.com/4776/47737656-4e694a00-dc69-11e8-821c-0bdbe1b79261.gif)

Is it a bit... unwieldy perhaps?

Selecting one shows you reports within that constituency:

![anglesey](https://user-images.githubusercontent.com/4776/47737679-5aeda280-dc69-11e8-9100-3693ed8158c4.gif)

Fixes #82.